### PR TITLE
Rename git repo to github.com/bitnami/kubecfg

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ modified the input files.
 
 TL;DR: run `make vendor` whenever you add/remove a dependency. run `GO111MODULE=on go get -u .....` to update deps.
 
-This project uses `go mod`, Go modules feature implemented since Go 1.11. This feature needs to be turned on explicitly via the `GO111MODULE` env variable, if you checkout the `kubecfg` repo in its canonical location in the GOPATH (i.e. $GOPATH/github.com/ksonnet/kubecfg).  This feature is turned on _automatically_ if you checkout the `kubecfg` repo anywhere else in the filesystem.
+This project uses `go mod`, Go modules feature implemented since Go 1.11. This feature needs to be turned on explicitly via the `GO111MODULE` env variable, if you checkout the `kubecfg` repo in its canonical location in the GOPATH (i.e. $GOPATH/github.com/bitnami/kubecfg).  This feature is turned on _automatically_ if you checkout the `kubecfg` repo anywhere else in the filesystem.
 
 
 This repository is configured to use Go modules as a source of truth for dependency information,

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # kubecfg
 
-[![Build Status](https://travis-ci.org/ksonnet/kubecfg.svg?branch=master)](https://travis-ci.org/ksonnet/kubecfg)
-[![Go Report Card](https://goreportcard.com/badge/github.com/ksonnet/kubecfg)](https://goreportcard.com/report/github.com/ksonnet/kubecfg)
+[![Build Status](https://travis-ci.org/bitnami/kubecfg.svg?branch=master)](https://travis-ci.org/bitnami/kubecfg)
+[![Go Report Card](https://goreportcard.com/badge/github.com/bitnami/kubecfg)](https://goreportcard.com/report/github.com/bitnami/kubecfg)
 
 A tool for managing Kubernetes resources as code.
 
@@ -17,7 +17,7 @@ similarly-named internal tool ;)
 ## Install
 
 Pre-compiled executables exist for some platforms on
-the [Github releases](https://github.com/ksonnet/kubecfg/releases)
+the [Github releases](https://github.com/bitnami/kubecfg/releases)
 page.
 
 On macOS, it can also be installed via [Homebrew](https://brew.sh/):
@@ -27,7 +27,7 @@ To build from source:
 
 ```console
 % PATH=$PATH:$GOPATH/bin
-% go get github.com/ksonnet/kubecfg
+% go get github.com/bitnami/kubecfg
 ```
 
 ## Quickstart

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -18,7 +18,7 @@ package cmd
 import (
 	"github.com/spf13/cobra"
 
-	"github.com/ksonnet/kubecfg/pkg/kubecfg"
+	"github.com/bitnami/kubecfg/pkg/kubecfg"
 )
 
 const (

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -18,7 +18,7 @@ package cmd
 import (
 	"github.com/spf13/cobra"
 
-	"github.com/ksonnet/kubecfg/pkg/kubecfg"
+	"github.com/bitnami/kubecfg/pkg/kubecfg"
 )
 
 const flagDiffStrategy = "diff-strategy"

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -40,7 +40,7 @@ import (
 	"k8s.io/client-go/restmapper"
 	"k8s.io/client-go/tools/clientcmd"
 
-	"github.com/ksonnet/kubecfg/utils"
+	"github.com/bitnami/kubecfg/utils"
 
 	// Register auth plugins
 	_ "k8s.io/client-go/plugin/pkg/client/auth"

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -18,7 +18,7 @@ package cmd
 import (
 	"github.com/spf13/cobra"
 
-	"github.com/ksonnet/kubecfg/pkg/kubecfg"
+	"github.com/bitnami/kubecfg/pkg/kubecfg"
 )
 
 const (

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -18,7 +18,7 @@ package cmd
 import (
 	"github.com/spf13/cobra"
 
-	"github.com/ksonnet/kubecfg/pkg/kubecfg"
+	"github.com/bitnami/kubecfg/pkg/kubecfg"
 )
 
 const (

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -18,7 +18,7 @@ package cmd
 import (
 	"github.com/spf13/cobra"
 
-	"github.com/ksonnet/kubecfg/pkg/kubecfg"
+	"github.com/bitnami/kubecfg/pkg/kubecfg"
 )
 
 const (

--- a/examples/guestbook.jsonnet
+++ b/examples/guestbook.jsonnet
@@ -24,9 +24,8 @@
 // kubecfg delete guestbook.jsonnet
 // ```
 
-// This example uses kube.libsonnet from Bitnami.  There are several
-// other Kubernetes libraries available (notably ksonnet/ksonnet-lib),
-// or write your own!
+// This example uses kube.libsonnet from Bitnami.  There are other
+// Kubernetes libraries available, or write your own!
 local kube = import "https://github.com/bitnami-labs/kube-libsonnet/raw/52ba963ca44f7a4960aeae9ee0fbee44726e481f/kube.libsonnet";
 
 // A function that returns 2 k8s objects: a redis Deployment and Service

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/ksonnet/kubecfg
+module github.com/bitnami/kubecfg
 
 require (
 	contrib.go.opencensus.io/exporter/ocagent v0.4.6 // indirect

--- a/integration/update_test.go
+++ b/integration/update_test.go
@@ -12,7 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 
-	"github.com/ksonnet/kubecfg/pkg/kubecfg"
+	"github.com/bitnami/kubecfg/pkg/kubecfg"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/main.go
+++ b/main.go
@@ -20,8 +20,8 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
-	"github.com/ksonnet/kubecfg/cmd"
-	"github.com/ksonnet/kubecfg/pkg/kubecfg"
+	"github.com/bitnami/kubecfg/cmd"
+	"github.com/bitnami/kubecfg/pkg/kubecfg"
 )
 
 // Version is overridden using `-X main.version` during release builds

--- a/pkg/kubecfg/delete.go
+++ b/pkg/kubecfg/delete.go
@@ -27,7 +27,7 @@ import (
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
 
-	"github.com/ksonnet/kubecfg/utils"
+	"github.com/bitnami/kubecfg/utils"
 )
 
 // DeleteCmd represents the delete subcommand

--- a/pkg/kubecfg/diff.go
+++ b/pkg/kubecfg/diff.go
@@ -33,7 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/dynamic"
 
-	"github.com/ksonnet/kubecfg/utils"
+	"github.com/bitnami/kubecfg/utils"
 )
 
 var ErrDiffFound = fmt.Errorf("Differences found.")
@@ -184,7 +184,7 @@ func removeMapFields(config, live map[string]interface{}) map[string]interface{}
 		v2, ok := live[k]
 		if !ok {
 			// Copy empty value from config, as API won't return them,
-			// see https://github.com/ksonnet/kubecfg/issues/179
+			// see https://github.com/bitnami/kubecfg/issues/179
 			if isEmptyValue(v1) {
 				result[k] = v1
 			}

--- a/pkg/kubecfg/update.go
+++ b/pkg/kubecfg/update.go
@@ -18,7 +18,7 @@ import (
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
 
-	"github.com/ksonnet/kubecfg/utils"
+	"github.com/bitnami/kubecfg/utils"
 )
 
 const (

--- a/pkg/kubecfg/update_test.go
+++ b/pkg/kubecfg/update_test.go
@@ -6,7 +6,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
-	"github.com/ksonnet/kubecfg/utils"
+	"github.com/bitnami/kubecfg/utils"
 )
 
 func TestStringListContains(t *testing.T) {

--- a/pkg/kubecfg/validate.go
+++ b/pkg/kubecfg/validate.go
@@ -28,7 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/discovery"
 
-	"github.com/ksonnet/kubecfg/utils"
+	"github.com/bitnami/kubecfg/utils"
 )
 
 // ValidateCmd represents the validate subcommand


### PR DESCRIPTION
Parent ksonnet project is shutting down.
Move repo to bitnami/kubecfg and rename URLs and golang imports
accordingly.