### PR TITLE
Add Validating/MutatingWebhookConfiguration to sort order

### DIFF
--- a/utils/sort_test.go
+++ b/utils/sort_test.go
@@ -105,6 +105,7 @@ func TestDepSort(t *testing.T) {
 		newObj("v1", "ReplicationController"),
 		newObj("v1", "ConfigMap"),
 		newObj("v1", "Namespace"),
+		newObj("admissionregistration.k8s.io/v1beta1", "MutatingWebhookConfiguration"),
 		newObj("bogus/v1", "UnknownKind"),
 		newObj("apiextensions.k8s.io/v1beta1", "CustomResourceDefinition"),
 	}
@@ -126,7 +127,10 @@ func TestDepSort(t *testing.T) {
 		t.Error("Namespace should be sorted second")
 	}
 	if objs[4].GetKind() != "ReplicationController" {
-		t.Error("RC should be sorted after other objects")
+		t.Error("RC should be sorted after non-pod objects")
+	}
+	if objs[5].GetKind() != "MutatingWebhookConfiguration" {
+		t.Error("Webhook should be sorted last")
 	}
 }
 


### PR DESCRIPTION
Webhook resources are hard to sort in the general case :(

`MutatingWebhookConfiguration` resources potentially have side effects
on following objects, and thus are inherently not declarative.

More practically, `MutatingWebhookConfiguration` and
`ValidatingWebhookConfiguration` may refer to in-cluster services that
need to be operationational before the Webhook is configured.

This change sorts `{Mutating,Validating}WebhookConfiguration`
resources _last_, when creating/updating.

Note that (because it is sorted last) the webhook will not have
affects on other objects in the same `kubecfg` run. It is thus up to
the config author to anticipate this and separately ensure the
resources are valid (ValidatingWebhook) or independently apply any
required transformations (MutatingWebhook).  An alternative is to
externally force resource ordering by invoking `kubecfg` more than
once with each "phase" of configuration.