### PR TITLE
add flag to omit secrets in diff

### DIFF
--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -21,10 +21,14 @@ import (
 	"github.com/bitnami/kubecfg/pkg/kubecfg"
 )
 
-const flagDiffStrategy = "diff-strategy"
+const (
+	flagDiffStrategy = "diff-strategy"
+	flagOmitSecrets  = "omit-secrets"
+)
 
 func init() {
 	diffCmd.PersistentFlags().String(flagDiffStrategy, "all", "Diff strategy, all or subset.")
+	diffCmd.PersistentFlags().Bool(flagOmitSecrets, false, "hide secret details when showing diff")
 	RootCmd.AddCommand(diffCmd)
 }
 
@@ -39,6 +43,11 @@ var diffCmd = &cobra.Command{
 		c := kubecfg.DiffCmd{}
 
 		c.DiffStrategy, err = flags.GetString(flagDiffStrategy)
+		if err != nil {
+			return err
+		}
+
+		c.OmitSecrets, err = flags.GetBool(flagOmitSecrets)
 		if err != nil {
 			return err
 		}

--- a/pkg/kubecfg/diff.go
+++ b/pkg/kubecfg/diff.go
@@ -41,7 +41,7 @@ var ErrDiffFound = fmt.Errorf("Differences found.")
 // Matches all the line starts on a diff text, which is where we put diff markers and indent
 var DiffLineStart = regexp.MustCompile("(^|\n)(.)")
 
-var DiffKeyValue = regexp.MustCompile(`"([[:alnum:]_-]+)":\s"([[:alnum:]=+]+)",?`)
+var DiffKeyValue = regexp.MustCompile(`"([-._a-zA-Z0-9]+)":\s"([[:alnum:]=+]+)",?`)
 
 // DiffCmd represents the diff subcommand
 type DiffCmd struct {

--- a/pkg/kubecfg/diff.go
+++ b/pkg/kubecfg/diff.go
@@ -23,7 +23,6 @@ import (
 	"os"
 	"regexp"
 	"sort"
-	"strings"
 
 	isatty "github.com/mattn/go-isatty"
 	"github.com/sergi/go-diff/diffmatchpatch"
@@ -41,6 +40,8 @@ var ErrDiffFound = fmt.Errorf("Differences found.")
 
 // Matches all the line starts on a diff text, which is where we put diff markers and indent
 var DiffLineStart = regexp.MustCompile("(^|\n)(.)")
+
+var DiffKeyValue = regexp.MustCompile(`"([[:alnum:]_-]+)":\s"([[:alnum:]=+]+)",?`)
 
 // DiffCmd represents the diff subcommand
 type DiffCmd struct {
@@ -121,8 +122,7 @@ func (c DiffCmd) formatDiff(diffs []diffmatchpatch.Diff, color bool, omitchanges
 		text := diff.Text
 
 		if omitchanges {
-			parts := strings.Split(text, ":")
-			text = parts[0] + ": <omitted>\n"
+			text = DiffKeyValue.ReplaceAllString(text, "$1: <omitted>")
 		}
 		switch diff.Type {
 		case diffmatchpatch.DiffInsert:


### PR DESCRIPTION
We use the diff functionality in our CI/CD pipeline to show pending changes before each deployment. Since those pipelines can be viewed by everyone, i've added a flag to alter the diff produced by secrets. An example diff would look like this:

```.diff
---
- live secrets example
+ config secrets example
-     "SSO_TOKEN": <omitted>
+     "SSO_TOKEN": <omitted>
```
