### PR TITLE
Define "ext-code," "ext-code-file," "tla-code," and "tla-code-file" command-line flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ kubecfg:
 	CGO_ENABLED=0 $(GO) build $(GO_FLAGS) $(GO_BUILDFLAGS) .
 
 generate:
-	$(GO) generate -x $(GO_PACKAGES)
+	$(GO) generate -x $(GO_FLAGS) $(GO_PACKAGES)
 
 test: gotest jsonnettest
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -250,20 +250,21 @@ func JsonnetVM(cmd *cobra.Command) (*jsonnet.VM, error) {
 
 	vm.Importer(utils.MakeUniversalImporter(searchUrls))
 
-	for flagName, spec := range map[string]struct {
+	for _, spec := range []struct {
+		flagName string
 		inject   func(string, string)
 		fromFile bool
 	}{
-		flagExtVar:      {vm.ExtVar, false},
-		flagExtVarFile:  {vm.ExtVar, true},
-		flagExtCode:     {vm.ExtCode, false},
-		flagExtCodeFile: {vm.ExtCode, true},
-		flagTLAVar:      {vm.TLAVar, false},
-		flagTLAVarFile:  {vm.TLAVar, true},
-		flagTLACode:     {vm.TLACode, false},
-		flagTLACodeFile: {vm.TLACode, true},
+		{flagExtVar, vm.ExtVar, false},
+		{flagExtVarFile, vm.ExtVar, true},
+		{flagExtCode, vm.ExtCode, false},
+		{flagExtCodeFile, vm.ExtCode, true},
+		{flagTLAVar, vm.TLAVar, false},
+		{flagTLAVarFile, vm.TLAVar, true},
+		{flagTLACode, vm.TLACode, false},
+		{flagTLACodeFile, vm.TLACode, true},
 	} {
-		entries, err := flags.GetStringSlice(flagName)
+		entries, err := flags.GetStringSlice(spec.flagName)
 		if err != nil {
 			return nil, err
 		}
@@ -271,7 +272,7 @@ func JsonnetVM(cmd *cobra.Command) (*jsonnet.VM, error) {
 			kv := strings.SplitN(entry, "=", 2)
 			if spec.fromFile {
 				if len(kv) != 2 {
-					return nil, fmt.Errorf("Failed to parse %s: missing '=' in %s", flagName, entry)
+					return nil, fmt.Errorf("Failed to parse %s: missing '=' in %s", spec.flagName, entry)
 				}
 				v, err := ioutil.ReadFile(kv[1])
 				if err != nil {


### PR DESCRIPTION
Mirroring the _jsonnet_ tool's command-line flags for consuming externally supplied Jsonnet code as injected values, define the four new flags:
- `--ext-code`
- `--ext-code-file`
- `--tla-code`
- `--tla-code-file`

Fixes #63.