### PR TITLE
Add a Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM golang:1.13 AS build
+ARG VERSION
+
+
+WORKDIR /go/src/kubecfg
+COPY . .
+
+RUN make
+
+FROM gcr.io/distroless/base
+COPY --from=build /go/src/kubecfg/kubecfg /
+CMD ["/kubecfg"]

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,8 @@
 
 VERSION ?= dev-$(shell date +%FT%T%z)
 
+BUILDER ?= podman
+IMAGE ?= kubecfg
 GO ?= go
 GO_FLAGS ?= -mod=vendor
 GO_LDFLAGS ?=
@@ -38,6 +40,9 @@ all: kubecfg
 
 kubecfg:
 	CGO_ENABLED=0 $(GO) build $(GO_FLAGS) $(GO_BUILDFLAGS) .
+
+image:
+	$(BUILDER) build -t $(IMAGE) --build-arg=VERSION=$(VERSION) .
 
 generate:
 	$(GO) generate -x $(GO_FLAGS) $(GO_PACKAGES)
@@ -67,5 +72,6 @@ vendor:
 clean:
 	$(RM) ./kubecfg
 
-.PHONY: all test clean vet fmt vendor
+
+.PHONY: all test clean vet fmt vendor image
 .PHONY: kubecfg


### PR DESCRIPTION
This PR simply adds a Dockerfile as well as a new make target to build it. Currently defaults to `docker` as build command but can be easily switched to `podman` or `buildah`