### PR TITLE
validate if name is set

### DIFF
--- a/pkg/kubecfg/diff.go
+++ b/pkg/kubecfg/diff.go
@@ -67,6 +67,10 @@ func (c DiffCmd) Run(apiObjects []*unstructured.Unstructured, out io.Writer) err
 			return err
 		}
 
+		if obj.GetName() == "" {
+			return fmt.Errorf("Error fetching one of the %s: it does not have a name set", utils.ResourceNameFor(c.Mapper, obj))
+		}
+
 		liveObj, err := client.Get(obj.GetName(), metav1.GetOptions{})
 		if err != nil && errors.IsNotFound(err) {
 			log.Debugf("%s doesn't exist on the server", desc)

--- a/pkg/kubecfg/validate.go
+++ b/pkg/kubecfg/validate.go
@@ -82,6 +82,9 @@ func (c ValidateCmd) Run(apiObjects []*unstructured.Unstructured, out io.Writer)
 			for _, err := range schema.Validate(obj) {
 				allErrs = append(allErrs, err)
 			}
+			if obj.GetName() == "" {
+				allErrs = append(allErrs, fmt.Errorf("An Object does not have a name set"))
+			}
 		}
 
 		for _, err := range allErrs {


### PR DESCRIPTION
This change simply checks if the name of the object is set. Without this check, the validation succeeds on typos like this:
```jsonnet
    metadata: { labels+: {"foo":"bar"}}
```
but will panic while updating with the following error, making it especially hard to debug:
```
panic: interface conversion: runtime.Object is *unstructured.UnstructuredList, not *unstructured.Unstructured
```