### PR TITLE
Parse tla/extvar options as StringArray not StringSlice

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -70,17 +70,17 @@ func init() {
 	RootCmd.PersistentFlags().StringArrayP(flagJpath, "J", nil, "Additional Jsonnet library search path, appended to the ones in the KUBECFG_JPATH env var. May be repeated.")
 	RootCmd.MarkPersistentFlagFilename(flagJpath)
 	RootCmd.PersistentFlags().StringArrayP(flagJUrl, "U", nil, "Additional Jsonnet library search path given as a URL. May be repeated.")
-	RootCmd.PersistentFlags().StringSliceP(flagExtVar, "V", nil, "Values of external variables with string values")
-	RootCmd.PersistentFlags().StringSlice(flagExtVarFile, nil, "Read external variables with string values from files")
+	RootCmd.PersistentFlags().StringArrayP(flagExtVar, "V", nil, "Values of external variables with string values")
+	RootCmd.PersistentFlags().StringArray(flagExtVarFile, nil, "Read external variables with string values from files")
 	RootCmd.MarkPersistentFlagFilename(flagExtVarFile)
-	RootCmd.PersistentFlags().StringSlice(flagExtCode, nil, "Values of external variables with values supplied as Jsonnet code")
-	RootCmd.PersistentFlags().StringSlice(flagExtCodeFile, nil, "Read external variables with values supplied as Jsonnet code from files")
+	RootCmd.PersistentFlags().StringArray(flagExtCode, nil, "Values of external variables with values supplied as Jsonnet code")
+	RootCmd.PersistentFlags().StringArray(flagExtCodeFile, nil, "Read external variables with values supplied as Jsonnet code from files")
 	RootCmd.MarkPersistentFlagFilename(flagExtCodeFile)
-	RootCmd.PersistentFlags().StringSliceP(flagTLAVar, "A", nil, "Values of top level arguments with string values")
-	RootCmd.PersistentFlags().StringSlice(flagTLAVarFile, nil, "Read top level arguments with string values from files")
+	RootCmd.PersistentFlags().StringArrayP(flagTLAVar, "A", nil, "Values of top level arguments with string values")
+	RootCmd.PersistentFlags().StringArray(flagTLAVarFile, nil, "Read top level arguments with string values from files")
 	RootCmd.MarkPersistentFlagFilename(flagTLAVarFile)
-	RootCmd.PersistentFlags().StringSlice(flagTLACode, nil, "Values of top level arguments with values supplied as Jsonnet code")
-	RootCmd.PersistentFlags().StringSlice(flagTLACodeFile, nil, "Read top level arguments with values supplied as Jsonnet code from files")
+	RootCmd.PersistentFlags().StringArray(flagTLACode, nil, "Values of top level arguments with values supplied as Jsonnet code")
+	RootCmd.PersistentFlags().StringArray(flagTLACodeFile, nil, "Read top level arguments with values supplied as Jsonnet code from files")
 	RootCmd.MarkPersistentFlagFilename(flagTLACodeFile)
 	RootCmd.PersistentFlags().String(flagResolver, "noop", "Change implementation of resolveImage native function. One of: noop, registry")
 	RootCmd.PersistentFlags().String(flagResolvFail, "warn", "Action when resolveImage fails. One of ignore,warn,error")
@@ -271,7 +271,7 @@ func JsonnetVM(cmd *cobra.Command) (*jsonnet.VM, error) {
 		{flagTLACode, vm.TLACode, true, false},
 		{flagTLACodeFile, vm.TLACode, true, true},
 	} {
-		entries, err := flags.GetStringSlice(spec.flagName)
+		entries, err := flags.GetStringArray(spec.flagName)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/show_test.go
+++ b/cmd/show_test.go
@@ -77,7 +77,8 @@ func TestShow(t *testing.T) {
   "notAnotherVal": "aVal2",
   "filevar": "foo\n",
   "array": ["one", 2, [3]],
-  "object": {"foo": "bar"}
+  "object": {"foo": "bar"},
+  "extcode": {"foo": 1, "bar": "test"}
 }
 `
 
@@ -97,6 +98,7 @@ func TestShow(t *testing.T) {
 			"-V", "aVar=aVal",
 			"-V", "anVar",
 			"--ext-str-file", "filevar=" + filepath.FromSlash("../testdata/extvar.file"),
+			"--ext-code", `extcode={foo: 1, bar: "test"}`,
 		})
 		defer resetFlagsOf(RootCmd)
 

--- a/testdata/test.jsonnet
+++ b/testdata/test.jsonnet
@@ -2,6 +2,7 @@ local test = import "test.libsonnet";
 local aVar = std.extVar("aVar");
 local anVar = std.extVar("anVar");
 local filevar = std.extVar("filevar");
+local extcode = std.extVar("extcode");
 
 {
   apiVersion: "v1",
@@ -12,6 +13,7 @@ local filevar = std.extVar("filevar");
       notAVal : aVar,
       notAnotherVal : anVar,
       filevar : filevar,
+      extcode: extcode,
     }
   ],
 }


### PR DESCRIPTION
The command line flags for top-level args (TLAs) and external variables
(extVars) were being parsed with the Cobra flag type of StringSlice. A
StringSlice allows multiple arguments with one flag name by separating
the values with a comma. This means a comma cannot be used in the
values. Also, Cobra StringSlice parses the argument with encoding/csv
which escapes double-quotes in the value.

For code arguments, we need the value to be passed unchanged. Cobra
StringArray does this, but does not allow the form --var=1,2,3 to provide
a list of [1, 2, 3].

Change all of the --ext and --tla argument processing to use StringArray
instead of StringSlice. This will change the behaviour for parsing
non-code argument, but it could be argued that using StringSlice in the
non-code arguments is also wrong. --ext-str foo=bar,baz means set foo to
bar and baz to the value from the environment. There is no way to set
foo to "bar,baz".

So let's make all cases possible at the expense of slightly more
verbosity in a few cases (--ext-str foo=bar --ext-str baz) and use
StringArray everywhere. This is also in line with the jsonnet command
line parsing.

Update the test cases to include a test for an extVar with a comma and
double quotes.

Fixes: #280