### PR TITLE
Import jsonnet paths passed on the command line via the VM

### DIFF
--- a/utils/acquire.go
+++ b/utils/acquire.go
@@ -149,21 +149,39 @@ func jsonWalk(parentCtx *walkContext, obj interface{}) ([]interface{}, error) {
 	}
 }
 
+func pathToURL(path string) (*url.URL, error) {
+	// Try to parse the path as is
+	u, err := url.Parse(path)
+	if err != nil {
+		return nil, err
+	}
+	// If no scheme was parsed, assume local file
+	if u.Scheme == "" {
+		u.Scheme = "file"
+	}
+	// If it is a local file, enforce absolute path
+	if u.Scheme == "file" {
+		abs, err := filepath.Abs(u.Path)
+		if err != nil {
+			return nil, err
+		}
+		u.Path = filepath.ToSlash(abs)
+	}
+	return u, nil
+}
+
 func jsonnetReader(vm *jsonnet.VM, path string) ([]runtime.Object, error) {
-	// TODO: Read via Importer, so we support HTTP, etc for first
-	// file too.
-	abs, err := filepath.Abs(path)
-	if err != nil {
-		return nil, err
-	}
-	pathUrl := &url.URL{Scheme: "file", Path: filepath.ToSlash(abs)}
-
-	bytes, err := ioutil.ReadFile(path)
+	pathUrl, err := pathToURL(path)
 	if err != nil {
 		return nil, err
 	}
 
-	jsonstr, err := vm.EvaluateSnippet(pathUrl.String(), string(bytes))
+	contents, _, err := vm.ImportData("", pathUrl.String())
+	if err != nil {
+		return nil, err
+	}
+
+	jsonstr, err := vm.EvaluateSnippet(pathUrl.String(), contents)
 	if err != nil {
 		return nil, err
 	}

--- a/utils/acquire_test.go
+++ b/utils/acquire_test.go
@@ -17,6 +17,9 @@ package utils
 
 import (
 	"encoding/json"
+	"net/url"
+	"os"
+	"path/filepath"
 	"reflect"
 	"sort"
 	"testing"
@@ -102,6 +105,66 @@ func TestJsonWalk(t *testing.T) {
 		})
 		if !reflect.DeepEqual(objs, test.result) {
 			t.Errorf("Expected %v, got %v", test.result, objs)
+		}
+	}
+}
+
+func TestPathToURL(t *testing.T) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		input  string
+		result url.URL
+		error  bool
+	}{
+		// generic relative path
+		{
+			input:  "./test.jsonnet",
+			result: url.URL{Scheme: "file", Path: filepath.Join(cwd, "test.jsonnet")},
+		},
+		// generic absolute path
+		{
+			input:  "/tmp/test.jsonnet",
+			result: url.URL{Scheme: "file", Path: "/tmp/test.jsonnet"},
+		},
+		// generic file:// path
+		{
+			input:  "file:///tmp/test.jsonnet",
+			result: url.URL{Scheme: "file", Path: "/tmp/test.jsonnet"},
+		},
+		// Some URL
+		{
+			input:  "https://raw.githubusercontent.com/example/repository/main/deploy.jsonnet",
+			result: url.URL{Scheme: "https", Host: "raw.githubusercontent.com", Path: "/example/repository/main/deploy.jsonnet"},
+		},
+		// Leading white space should be an example of breaking url.Parse
+		{
+			input: "  https://test.example.com",
+			error: true,
+		},
+	}
+
+	for i, test := range tests {
+		out, err := pathToURL(test.input)
+		if test.error {
+			// expect error
+			if err == nil {
+				t.Errorf("Test %d failed to fail", i)
+			}
+			continue
+		}
+
+		// expect success
+		if err != nil {
+			t.Errorf("Test %d failed: %v", i, err)
+			continue
+		}
+
+		if !reflect.DeepEqual(*out, test.result) {
+			t.Errorf("Expected %+v, got %+v", test.result, *out)
 		}
 	}
 }


### PR DESCRIPTION
This is regarding our discussion in Slack. It felt like an easy, low hanging fruit, type thing to make possible real quick. 

Could potentially use more test cases. However, locally I was able to utilize it like so:

```bash
# Existing behavior
./kubecfg show ./example.jsonnet
# ...
#
# Some remote file
./kubecfg show https://raw.githubusercontent.com/bitnami/kube-prod-runtime/master/manifests/components/nginx-ingress.jsonnet
# ...
# ...
# Apply some remote file
./kubecfg update https://raw.githubusercontent.com/bitnami/kube-prod-runtime/master/manifests/components/nginx-ingress.jsonnet
INFO  Validating deployments kubeprod.nginx-ingress-controller
INFO  validate object "apps/v1, Kind=Deployment"
INFO  Validating clusterroles nginx-ingress-controller
INFO  validate object "rbac.authorization.k8s.io/v1beta1, Kind=ClusterRole"
INFO  Validating roles kubeprod.nginx-ingress-controller
INFO  validate object "rbac.authorization.k8s.io/v1beta1, Kind=Role"
INFO  Validating services kubeprod.nginx-ingress
INFO  validate object "/v1, Kind=Service"
INFO  Validating configmaps kubeprod.tcp-services-67c1890
INFO  validate object "/v1, Kind=ConfigMap"
INFO  Validating configmaps kubeprod.udp-services-67c1890
INFO  validate object "/v1, Kind=ConfigMap"
INFO  Validating configmaps kubeprod.nginx-ingress-0ff949c
INFO  validate object "/v1, Kind=ConfigMap"
INFO  Validating horizontalpodautoscalers kubeprod.nginx-ingress-controller
INFO  validate object "autoscaling/v1, Kind=HorizontalPodAutoscaler"
INFO  Validating clusterrolebindings nginx-ingress-controller
INFO  validate object "rbac.authorization.k8s.io/v1beta1, Kind=ClusterRoleBinding"
INFO  Validating rolebindings kubeprod.nginx-ingress-controller
INFO  validate object "rbac.authorization.k8s.io/v1beta1, Kind=RoleBinding"
INFO  Validating poddisruptionbudgets kubeprod.nginx-ingress-controller
INFO  validate object "policy/v1beta1, Kind=PodDisruptionBudget"
INFO  Validating serviceaccounts kubeprod.nginx-ingress-controller
INFO  validate object "/v1, Kind=ServiceAccount"
INFO  Fetching schemas for 12 resources
W0603 12:33:15.306538  560040 warnings.go:67] rbac.authorization.k8s.io/v1beta1 ClusterRole is deprecated in v1.17+, unavailable in v1.22+; use rbac.authorization.k8s.io/v1 ClusterRole
INFO  Creating clusterroles nginx-ingress-controller
W0603 12:33:15.312277  560040 warnings.go:67] rbac.authorization.k8s.io/v1beta1 ClusterRole is deprecated in v1.17+, unavailable in v1.22+; use rbac.authorization.k8s.io/v1 ClusterRole
W0603 12:33:15.401767  560040 warnings.go:67] rbac.authorization.k8s.io/v1beta1 ClusterRoleBinding is deprecated in v1.17+, unavailable in v1.22+; use rbac.authorization.k8s.io/v1 ClusterRoleBinding
INFO  Creating clusterrolebindings nginx-ingress-controller
W0603 12:33:15.406635  560040 warnings.go:67] rbac.authorization.k8s.io/v1beta1 ClusterRoleBinding is deprecated in v1.17+, unavailable in v1.22+; use rbac.authorization.k8s.io/v1 ClusterRoleBinding
INFO  Creating services kubeprod.nginx-ingress
INFO  Creating configmaps kubeprod.nginx-ingress-0ff949c
INFO  Creating horizontalpodautoscalers kubeprod.nginx-ingress-controller
W0603 12:33:15.507259  560040 warnings.go:67] policy/v1beta1 PodDisruptionBudget is deprecated in v1.21+, unavailable in v1.25+; use policy/v1 PodDisruptionBudget
INFO  Creating poddisruptionbudgets kubeprod.nginx-ingress-controller
W0603 12:33:15.708563  560040 warnings.go:67] policy/v1beta1 PodDisruptionBudget is deprecated in v1.21+, unavailable in v1.25+; use policy/v1 PodDisruptionBudget
W0603 12:33:15.907006  560040 warnings.go:67] rbac.authorization.k8s.io/v1beta1 Role is deprecated in v1.17+, unavailable in v1.22+; use rbac.authorization.k8s.io/v1 Role
INFO  Creating roles kubeprod.nginx-ingress-controller
W0603 12:33:16.108283  560040 warnings.go:67] rbac.authorization.k8s.io/v1beta1 Role is deprecated in v1.17+, unavailable in v1.22+; use rbac.authorization.k8s.io/v1 Role
W0603 12:33:16.307254  560040 warnings.go:67] rbac.authorization.k8s.io/v1beta1 RoleBinding is deprecated in v1.17+, unavailable in v1.22+; use rbac.authorization.k8s.io/v1 RoleBinding
INFO  Creating rolebindings kubeprod.nginx-ingress-controller
W0603 12:33:16.508205  560040 warnings.go:67] rbac.authorization.k8s.io/v1beta1 RoleBinding is deprecated in v1.17+, unavailable in v1.22+; use rbac.authorization.k8s.io/v1 RoleBinding
INFO  Creating serviceaccounts kubeprod.nginx-ingress-controller
INFO  Creating configmaps kubeprod.tcp-services-67c1890
INFO  Creating configmaps kubeprod.udp-services-67c1890
INFO  Creating deployments kubeprod.nginx-ingress-controller
```