### PR TITLE
Introduce new diff flag --ignore-status-field

### DIFF
--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -22,13 +22,15 @@ import (
 )
 
 const (
-	flagDiffStrategy = "diff-strategy"
-	flagOmitSecrets  = "omit-secrets"
+	flagDiffStrategy      = "diff-strategy"
+	flagOmitSecrets       = "omit-secrets"
+	flagIgnoreStatusField = "ignore-status-field"
 )
 
 func init() {
 	diffCmd.PersistentFlags().String(flagDiffStrategy, "all", "Diff strategy, all, subset or last-applied")
 	diffCmd.PersistentFlags().Bool(flagOmitSecrets, false, "hide secret details when showing diff")
+	diffCmd.PersistentFlags().Bool(flagIgnoreStatusField, false, "ignore the top-level .status field when comparing diffs")
 	RootCmd.AddCommand(diffCmd)
 }
 
@@ -48,6 +50,11 @@ var diffCmd = &cobra.Command{
 		}
 
 		c.OmitSecrets, err = flags.GetBool(flagOmitSecrets)
+		if err != nil {
+			return err
+		}
+
+		c.IgnoreStatusField, err = flags.GetBool(flagIgnoreStatusField)
 		if err != nil {
 			return err
 		}

--- a/pkg/kubecfg/diff.go
+++ b/pkg/kubecfg/diff.go
@@ -46,10 +46,11 @@ var DiffKeyValue = regexp.MustCompile(`"([-._a-zA-Z0-9]+)":\s"([[:alnum:]=+]+)",
 
 // DiffCmd represents the diff subcommand
 type DiffCmd struct {
-	Client           dynamic.Interface
-	Mapper           meta.RESTMapper
-	DefaultNamespace string
-	OmitSecrets      bool
+	Client            dynamic.Interface
+	Mapper            meta.RESTMapper
+	DefaultNamespace  string
+	OmitSecrets       bool
+	IgnoreStatusField bool
 
 	DiffStrategy string
 }
@@ -92,6 +93,18 @@ func (c DiffCmd) Run(ctx context.Context, apiObjects []*unstructured.Unstructure
 		if err != nil {
 			return err
 		}
+
+		if c.IgnoreStatusField {
+			_, foundLive := liveObjMap["status"]
+			if foundLive {
+				delete(liveObjMap, "status")
+			}
+			_, foundObj := obj.Object["status"]
+			if foundObj {
+				delete(obj.Object, "status")
+			}
+		}
+
 		liveObjText, _ := json.MarshalIndent(liveObjMap, "", "  ")
 		objText, _ := json.MarshalIndent(obj.Object, "", "  ")
 


### PR DESCRIPTION
Introduce new diff flag `--ignore-status-field` which can be used to ignore the top-level `.status` field when comparing diffs.

In some cases when performing a diff on resources the only shown change is the `.status` field. Seeing as this field is only updated on the live object, it doesn't make much sense to show a diff of it.

